### PR TITLE
Adding the setting "auto_minify_on_save"

### DIFF
--- a/Minifier.sublime-settings
+++ b/Minifier.sublime-settings
@@ -19,5 +19,8 @@
     "open_on_min": true,
 
     // HTTP Timeout
-    "timeout": 10
+    "timeout": 10,
+
+    //on save, should i auto generate a .min. version
+    "auto_minify_on_save": false
 }

--- a/Minify.py
+++ b/Minify.py
@@ -128,6 +128,15 @@ class BaseMinifier(sublime_plugin.TextCommand):
         endtypes = {'u': LF, 'w': CR+LF, 'm': CR}
         return endtypes[self.view.line_endings()[0].lower()]
 
+class MinifyAutoMagic(sublime_plugin.EventListener):
+    def on_post_save(self, view): 
+        self.settings = sublime.load_settings('Minifier.sublime-settings')  
+        file_can_minify_list = [ 'css', 'js']
+        if self.settings.get('auto_minify_on_save', False ) == True:
+            if view.file_name().split('.').pop().lower() in file_can_minify_list:
+                sublime.status_message(' Starting auto minify for ' + view.file_name() );
+                view.run_command('minify_to_file');
+                #sublime.message_dialog( " AutoMinifyAndSave " + view.file_name()  );
 
 class Minify(BaseMinifier):
 


### PR DESCRIPTION
This coupled with the auto save sublime setting allows me to switch
windows and have the min file automatically minified. Also, I suggest
setting the "open_on_min" to false if you use "auto_minify_on_save"
true.
